### PR TITLE
Updates the the line comment to hash instead of double-slash

### DIFF
--- a/terraform.configuration.json
+++ b/terraform.configuration.json
@@ -1,7 +1,7 @@
 {
 	"comments": {
 		// symbol used for single line comment. Remove this entry if your language does not support line comments
-		"lineComment": "//",
+		"lineComment": "#",
 		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
 		"blockComment": [ "/*", "*/" ]
 	},


### PR DESCRIPTION
This tells vscode that the single line comment is prefixed with a `#` instead of a `//`. The double-slash comment does appear to work, but:

a) it does not show up in the [official documentation](https://www.terraform.io/docs/configuration/syntax.html).
b) it is not syntax highlighted, but `#` comments are.

This is useful for automated block commenting and uncommenting in vscode with `ctrl+/`, which will use the wrong kind of comments until this is merged.