### PR TITLE
Recognize "data" resources.

### DIFF
--- a/syntaxes/terraform.tmLanguage
+++ b/syntaxes/terraform.tmLanguage
@@ -98,7 +98,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(resource)\s+(")(\w+)(")\s+(")(.+)(")\s+({)</string>
+			<string>(resource|data)\s+(")(\w+)(")\s+(")(.+)(")\s+({)</string>
 			<key>name</key>
 			<string>meta.resource.terraform</string>
 		</dict>


### PR DESCRIPTION
Previously, the terraform plugin for vscode only recognized resources starting with the keyword `resource`. But in Terraform 0.7.x, a new resource type `data` was introduced. This is a naive implementation to support that.

Note that while I'm using this locally, I have not tested this thoroughly, so this PR is more of an invitation to complete this work. There may be unique syntax for the `data` resources that this admittedly simple change doesn't account for.