### PR TITLE
Fixed single line terraform template comment

### DIFF
--- a/terraform.configuration.json
+++ b/terraform.configuration.json
@@ -1,7 +1,7 @@
 {
 	"comments": {
 		// symbol used for single line comment. Remove this entry if your language does not support line comments
-		"lineComment": "//",
+		"lineComment": "#",
 		// symbols used for start and end a block comment. Remove this entry if your language does not support block comments
 		"blockComment": [ "/*", "*/" ]
 	},


### PR DESCRIPTION
Based on HCL https://www.terraform.io/docs/configuration/syntax.html single line comment should be # instead of //
Thx