### PR TITLE
Added very basic terraform fmt runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 *.vsix
+.DS_Store
+node_modules/

--- a/package.json
+++ b/package.json
@@ -43,6 +43,11 @@
           "type": "boolean",
           "default": true,
           "description": "Run 'terraform fmt' on save."
+        },
+        "terraform.path": {
+          "type": "string",
+          "default": "terraform",
+          "description": "Path to the 'terraform' executable"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "terraform",
   "displayName": "Terraform",
   "description": "Adds syntax highlighting for Hashicorp's Terraform",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "publisher": "mauve",
   "engines": {
     "vscode": "^0.10.6"
@@ -59,8 +59,5 @@
     "mocha": "^2.3.3",
     "@types/node": "^6.0.40",
     "@types/mocha": "^2.2.32"
-  },
-  "dependencies": {
-    "vscode-languageserver": "^2.6.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,27 +1,66 @@
 {
-    "icon": "terraform.png",
-	"name": "terraform",
-	"displayName": "Terraform",
-	"description": "Adds syntax highlighting for Hashicorp's Terraform",
-	"version": "0.0.5",
-	"publisher": "mauve",
-	"engines": {
-		"vscode": "^0.10.6"
-	},
-	"categories": [
-		"Languages"
-	],
-	"contributes": {
-		"languages": [{
-			"id": "terraform",
-			"aliases": ["Terraform", "terraform"],
-			"extensions": [".tf",".tfvars"],
-			"configuration": "./terraform.configuration.json"
-		}],
-		"grammars": [{
-			"language": "terraform",
-			"scopeName": "source.terraform",
-			"path": "./syntaxes/terraform.tmLanguage"
-		}]
-	}
+  "icon": "terraform.png",
+  "name": "terraform",
+  "displayName": "Terraform",
+  "description": "Adds syntax highlighting for Hashicorp's Terraform",
+  "version": "0.0.5",
+  "publisher": "mauve",
+  "engines": {
+    "vscode": "^0.10.6"
+  },
+  "categories": [
+    "Other",
+    "Languages",
+    "Formatters"
+  ],
+  "activationEvents": [
+    "onLanguage:terraform"
+  ],
+  "main": "./out/src/extension",
+  "contributes": {
+    "languages": [{
+      "id": "terraform",
+      "aliases": [
+        "Terraform",
+        "terraform"
+      ],
+      "extensions": [
+        ".tf",
+        ".tfvars"
+      ],
+      "configuration": "./terraform.configuration.json"
+    }],
+    "grammars": [{
+      "language": "terraform",
+      "scopeName": "source.terraform",
+      "path": "./syntaxes/terraform.tmLanguage"
+    }],
+    "configuration": {
+      "type": "object",
+      "title": "Terraform configuration",
+      "properties": {
+        "terraform.formatOnSave": {
+          "type": "boolean",
+          "default": true,
+          "description": "Run 'terraform fmt' on save."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "tsc -p ./",
+    "compile": "tsc -watch -p ./",
+    "postinstall": "node ./node_modules/vscode/bin/install",
+    "test": "node ./node_modules/vscode/bin/test"
+  },
+  "devDependencies": {
+    "typescript": "^2.0.3",
+    "vscode": "^1.0.0",
+    "mocha": "^2.3.3",
+    "@types/node": "^6.0.40",
+    "@types/mocha": "^2.2.32"
+  },
+  "dependencies": {
+    "vscode-languageserver": "^2.6.2"
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,0 +1,54 @@
+'use strict';
+
+import * as vscode from 'vscode';
+import { exec } from 'child_process';
+
+const fullRange = doc => doc.validateRange(new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE));
+
+function fmt(text: string): Promise<string> {
+    return new Promise<string>((resolve, reject) => {
+        const child = exec('terraform fmt -', {
+            encoding: 'utf8',
+            maxBuffer: 1024 * 1024,
+        }, (error, stdout, stderr) => {
+            if (error) {
+                reject(stderr);
+            } else {
+                resolve(stdout);
+            }
+        });
+
+        child.stdin.write(text);
+        child.stdin.end();
+    });
+}
+
+export function activate(context: vscode.ExtensionContext) {
+    var onSave = vscode.workspace.onDidSaveTextDocument((document: vscode.TextDocument) => {
+        if (document.languageId !== 'terraform') {
+            return;
+        }
+
+        let terraformConfig = vscode.workspace.getConfiguration('terraform');
+        let textEditor = vscode.window.activeTextEditor;
+
+        if (terraformConfig['formatOnSave'] && textEditor.document === document) {
+            const range = fullRange(document);
+
+            fmt(document.getText())
+                .then((formattedText) => {
+                    textEditor.edit((editor) => {
+                        editor.replace(range, formattedText);
+                    });
+
+                    // sometimes the selections persistes if multiple lines are removed
+                    textEditor.selections.length = 0;
+                })
+                .catch((e) => {
+                    vscode.window.showErrorMessage(e);
+                });
+        }
+    });
+
+    context.subscriptions.push(onSave);
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,9 +5,9 @@ import { exec } from 'child_process';
 
 const fullRange = doc => doc.validateRange(new vscode.Range(0, 0, Number.MAX_VALUE, Number.MAX_VALUE));
 
-function fmt(text: string): Promise<string> {
+function fmt(execPath:String, text: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-        const child = exec('terraform fmt -', {
+        const child = exec(execPath + ' fmt -', {
             encoding: 'utf8',
             maxBuffer: 1024 * 1024,
         }, (error, stdout, stderr) => {
@@ -37,15 +37,12 @@ export function activate(context: vscode.ExtensionContext) {
         if (terraformConfig['formatOnSave'] && textEditor.document === document) {
             const range = fullRange(document);
 
-            fmt(document.getText())
+            fmt(terraformConfig['path'], document.getText())
                 .then((formattedText) => {
                     textEditor.edit((editor) => {
                         editor.replace(range, formattedText);
                     });
-
-                    // sometimes the selections persistes if multiple lines are removed
-                    // textEditor.selections.length = 0;
-                }).then(applied => {
+                }).then((applied) => {
                     ignoreNextSave.add(document);
 
                     return document.save();

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -1,0 +1,22 @@
+//
+// Note: This example test is leveraging the Mocha test framework.
+// Please refer to their documentation on https://mochajs.org/ for help.
+//
+
+// The module 'assert' provides assertion methods from node
+import * as assert from 'assert';
+
+// You can import and use all API from the 'vscode' module
+// as well as import your extension to test it
+import * as vscode from 'vscode';
+import * as myExtension from '../src/extension';
+
+// Defines a Mocha test suite to group tests of similar kind together
+suite("Extension Tests", () => {
+
+    // Defines a Mocha unit test
+    test("Something 1", () => {
+        assert.equal(-1, [1, 2, 3].indexOf(5));
+        assert.equal(-1, [1, 2, 3].indexOf(0));
+    });
+});

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,0 +1,22 @@
+//
+// PLEASE DO NOT MODIFY / DELETE UNLESS YOU KNOW WHAT YOU ARE DOING
+//
+// This file is providing the test runner to use when running extension tests.
+// By default the test runner in use is Mocha based.
+//
+// You can provide your own test runner if you want to override it by exporting
+// a function run(testRoot: string, clb: (error:Error) => void) that the extension
+// host can call to run the tests. The test runner is expected to use console.log
+// to report the results back to the caller. When the tests are finished, return
+// a possible error to the callback or null if none.
+
+var testRunner = require('vscode/lib/testrunner');
+
+// You can directly control Mocha options by uncommenting the following lines
+// See https://github.com/mochajs/mocha/wiki/Using-mocha-programmatically#set-options for more info
+testRunner.configure({
+    ui: 'tdd', 		// the TDD UI is being used in extension.test.ts (suite, test, etc.)
+    useColors: true // colored output from test results
+});
+
+module.exports = testRunner;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,16 @@
+{
+    "compilerOptions": {
+        "module": "commonjs",
+        "target": "es6",
+        "outDir": "out",
+        "lib": [
+            "es6"
+        ],
+        "sourceMap": true,
+        "rootDir": "."
+    },
+    "exclude": [
+        "node_modules",
+        ".vscode-test"
+    ]
+}


### PR DESCRIPTION
I added a configuration option for `terraform.formatOnSave` and a little function running `terraform fmt -` with the input from the document.

- [x] Make path to terraform configurable
- [x] Something is broken in the way the content is updated, see the go plugin for inspiration
- [x] Squash commits

Thoughts?