### PR TITLE
Add auto closing and surrounding pairs

### DIFF
--- a/terraform.configuration.json
+++ b/terraform.configuration.json
@@ -10,5 +10,19 @@
 		["{", "}"],
 		["[", "]"],
 		["(", ")"]
+	],
+	"autoClosingPairs": [
+		{ "open": "{", "close": "}" },
+		{ "open": "[", "close": "]" },
+		{ "open": "(", "close": ")" },
+		{ "open": "\"", "close": "\"", "notIn": ["string"] },
+		{ "open": "'", "close": "'", "notIn": ["string", "comment"] }
+	],
+	"surroundingPairs": [
+		["{", "}"],
+		["[", "]"],
+		["(", ")"],
+		["\"", "\""],
+		["'", "'"]
 	]
 }


### PR DESCRIPTION
This enables automatic quotes and other characters completion, as well
as the surrounding pair feature that allows selecting a word and putting
it inside brackets or quotes, for example.