### PR TITLE
Add support for local variable type

### DIFF
--- a/syntaxes/terraform.json
+++ b/syntaxes/terraform.json
@@ -64,7 +64,7 @@
       },
       "foldingStartMarker": "\\{\\s*$",
       "foldingStopMarker": "^\\s*\\}",
-      "match": "(provider|provisioner|variable|output|module|atlas)\\s+(\")?([\\w\\-]+)(\")?\\s+({)"
+      "match": "(locals|provider|provisioner|variable|output|module|atlas)\\s+(\")?([\\w\\-]+)(\")?\\s+({)"
     },
     {
       "captures": {
@@ -156,7 +156,7 @@
       "captures": {
         "0": { "name": "entity.other.attribute-name.terraform" }
       },
-      "match": "(terraform|var|self|count|module|path|data)(\\.[\\w\\-\\*]+)+"
+      "match": "(local|terraform|var|self|count|module|path|data)(\\.[\\w\\-\\*]+)+"
     },
     "strings": {
       "begin": "\\\"",


### PR DESCRIPTION
Terraform 0.10.4 introduced local variables with [documentation here](https://www.terraform.io/docs/configuration/locals.html).

This adds syntax support for keywords `local` and `locals`.