### PR TITLE
Show output channel on validation fail

### DIFF
--- a/src/validate.ts
+++ b/src/validate.ts
@@ -17,6 +17,7 @@ export function validateCommand() {
     }).catch((error) => {
       outputChannel.appendLine("terraform.validate: Failed:");
       outputChannel.append(error);
+      outputChannel.show(true);
       vscode.window.showErrorMessage("Validation failed, more information in the output tab.");
     });
 }


### PR DESCRIPTION
Make the output easy to find for users. I had a frustrating time finding the validation output (like in #34). This change highlights the output channel containing the validation warnings.

The previous behavior requires the user to find the 'Terraform' entry in the output pane's dropdown. This wasn't obvious to me.