### PR TITLE
Change child_process.exec to child_process.execFile.

### DIFF
--- a/src/format.ts
+++ b/src/format.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 
 import { stripAnsi } from './ansi';
 import { isTerraformDocument } from './helpers';
@@ -36,9 +36,9 @@ export class FormattingEditProvider implements vscode.DocumentFormattingEditProv
 
   private fmt(execPath: String, text: string): Promise<string> {
     return new Promise<string>((resolve, reject) => {
-      const commandLine = `${execPath} fmt -`;
+      const commandLineArgs = ["fmt", "-"];
 
-      const child = exec(commandLine, {
+      const child = execFile("${execPath}", commandLineArgs, {
         encoding: 'utf8',
         maxBuffer: 1024 * 1024,
       }, (error, stdout, stderr) => {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 
 import { errorDiagnosticCollection } from './extension';
 import { outputChannel } from './extension';
@@ -70,12 +70,12 @@ export function lintCommand() {
 
 function lint(execPath: string, lintConfig: string, workspaceDir: string): Promise<Issue[]> {
   return new Promise<any[]>((resolve, reject) => {
-    let commandLineParts = [execPath, "--format", "json"];
+    let commandLineArgs = ["--format", "json"];
     if (lintConfig !== null) {
-      commandLineParts.push("--config", lintConfig);
+      commandLineArgs.push("--config", lintConfig);
     }
 
-    const child = exec(commandLineParts.join(" "), {
+    const child = execFile(execPath, commandLineArgs, {
       cwd: workspaceDir,
       encoding: 'utf8',
       maxBuffer: 1024 * 1024

--- a/src/process.ts
+++ b/src/process.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 
 import { Parser } from './parser';
 
@@ -8,10 +8,10 @@ import { getConfiguration } from './configuration';
 export function process(text: string): Promise<Parser.IndexResult> {
   const cfg = getConfiguration();
   const path = cfg.indexing.indexerPath;
-  const commandLine = `${path} -`;
+  const commandLineArgs = ["-"];
 
   return new Promise<Parser.IndexResult>((resolve, reject) => {
-    let child = exec(commandLine, {
+    let child = execFile(path, commandLineArgs, {
       encoding: "utf8",
       cwd: vscode.workspace.rootPath
     }, (error, stdout, stderr) => {

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { outputChannel } from './extension';
 
 export function validateCommand() {
@@ -23,14 +23,13 @@ export function validateCommand() {
 }
 
 function validate(execPath: string, directory: string, workspaceDir: string): Promise<string> {
-  if (directory === undefined) {
-    directory = "";
-  }
-
   return new Promise<string>((resolve, reject) => {
-    const commandLine = `${execPath} validate -no-color ${directory}`;
+    let commandLineArgs = ["validate", "-no-color"];
+    if (directory !== undefined) {
+      commandLineArgs.push(directory);
+    }
 
-    const child = exec(commandLine, {
+    const child = execFile(execPath, commandLineArgs, {
       cwd: workspaceDir,
       encoding: 'utf8',
       maxBuffer: 1024 * 1024


### PR DESCRIPTION
Hi,

I placed `tflint.exe` in the directory that it contain some spaces (as like as `C:\Program Files`),
it is not work.

I replaced some `child_process.exec` to `child_process.execFile` to fix.