### PR TITLE
[Discussion] [Live Share] Restricting language services to local files

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,11 @@ import { CompletionProvider } from './providers';
 export let errorDiagnosticCollection = vscode.languages.createDiagnosticCollection("terraform-error");
 export let outputChannel = vscode.window.createOutputChannel("Terraform");
 
+const documentSelector: vscode.DocumentSelector = [
+    { language: "terraform", scheme: "file" },
+    { language: "terraform", scheme: "untitled" }
+];
+
 export function activate(ctx: vscode.ExtensionContext) {
     ctx.subscriptions.push(errorDiagnosticCollection);
 
@@ -16,15 +21,17 @@ export function activate(ctx: vscode.ExtensionContext) {
 
     // we need to manually handle save events otherwise format on autosave does not work
     ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument((doc) => formattingProvider.onSave(doc)));
-    vscode.languages.registerDocumentFormattingEditProvider('terraform', formattingProvider);
+    vscode.languages.registerDocumentFormattingEditProvider(documentSelector, formattingProvider);
 
     ctx.subscriptions.push(vscode.workspace.onDidChangeTextDocument(liveIndex));
 
     ctx.subscriptions.push(vscode.commands.registerCommand('terraform.validate', () => { validateCommand(); }));
     ctx.subscriptions.push(vscode.commands.registerCommand('terraform.lint', () => { lintCommand(); }));
 
-    ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider("terraform", new CompletionProvider, '.', '"'));
+    ctx.subscriptions.push(vscode.languages.registerCompletionItemProvider(documentSelector, new CompletionProvider, '.', '"'));
 
     // index operations
-    initializeIndex(ctx);
+    if (vscode.workspace.rootPath) {
+        initializeIndex(ctx);
+    }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,12 +18,7 @@ export function activate(ctx: vscode.ExtensionContext) {
     ctx.subscriptions.push(errorDiagnosticCollection);
 
     let formattingProvider = new FormattingEditProvider;
-
-    // we need to manually handle save events otherwise format on autosave does not work
-    ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument((doc) => formattingProvider.onSave(doc)));
     vscode.languages.registerDocumentFormattingEditProvider(documentSelector, formattingProvider);
-
-    ctx.subscriptions.push(vscode.workspace.onDidChangeTextDocument(liveIndex));
 
     ctx.subscriptions.push(vscode.commands.registerCommand('terraform.validate', () => { validateCommand(); }));
     ctx.subscriptions.push(vscode.commands.registerCommand('terraform.lint', () => { lintCommand(); }));
@@ -32,6 +27,10 @@ export function activate(ctx: vscode.ExtensionContext) {
 
     // index operations
     if (vscode.workspace.rootPath) {
+        // we need to manually handle save events otherwise format on autosave does not work
+        ctx.subscriptions.push(vscode.workspace.onDidSaveTextDocument((doc) => formattingProvider.onSave(doc)));
+        ctx.subscriptions.push(vscode.workspace.onDidChangeTextDocument(liveIndex));
+
         initializeIndex(ctx);
     }
 }


### PR DESCRIPTION
In preparation for [Visual Studio Live Share](https://aka.ms/vsls) adding support for "guests" to receive remote language services for Terraform, this PR simply updates the current `DocumentSelector` to be limited to `file` and `untitled` (unsaved) files. This way, when someone has the Terraform extension installed, and joins a Live Share session (where files use the `vsls:` scheme), their language services will be entirely derived from the remote/host side, which provides a more accurate and project-wide experience (guests in Live Share don't have local file access to the project they're collaborating with).

*Note: As an example, the TypeScript/JavaScript language services that come in-box with VS Code [already have this scheme restriction](https://github.com/Microsoft/vscode/blob/master/extensions/typescript-language-features/src/utils/fileSchemes.ts#L12), and so this PR replicates that behavior.*