### PR TITLE
Fix autocomplete of variables and outputs

### DIFF
--- a/src/autocompletion/completion-provider.ts
+++ b/src/autocompletion/completion-provider.ts
@@ -18,7 +18,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
   constructor(private index: Index) { }
 
   private getVariables(position: vscode.Position, includePrefix: boolean, match?: string): vscode.CompletionItem[] {
-    return this.index.query("ALL_FILES", { type: "variable", name: match }).map((variable) => {
+    return this.index.query("ALL_FILES", { section_type: "variable", name: match }).map((variable) => {
       let item = new vscode.CompletionItem(variable.name);
       item.kind = vscode.CompletionItemKind.Variable;
       if (includePrefix) {
@@ -30,7 +30,7 @@ export class CompletionProvider implements vscode.CompletionItemProvider {
   }
 
   private getOutputs(match?: string): vscode.CompletionItem[] {
-    return this.index.query("ALL_FILES", { type: "output", name: match }).map((output) => {
+    return this.index.query("ALL_FILES", { section_type: "output", name: match }).map((output) => {
       let item = new vscode.CompletionItem(output.name);
       item.kind = vscode.CompletionItemKind.Property;
       return item;


### PR DESCRIPTION
Looks like after some of the latest changes the autocompletion seems to be completely broken for me. I've seen autocomplete working somewhat well on a machine I have no access to at the moment, but I'm not sure what version it was running (not latest for sure).

I tried to test v1.0.5 (VSCode v1.23.0) that currently is the latest stable and it was still failing to me, so I dug in to see what was going on.

This MR addresses lookup of variables and outputs in the Index.

I still seem to experience issues with the rest of the autocomplete (resources, etc)