### PR TITLE
Add matching syntax for closing brackets

### DIFF
--- a/syntaxes/terraform.json
+++ b/syntaxes/terraform.json
@@ -6,6 +6,10 @@
   "name": "Terraform",
   "patterns": [
     {
+      "match": "^\\s*(})",
+      "name": "punctuation.definition.tag.terraform"
+    },
+    {
       "begin": "#|//",
       "captures": {
         "0": {


### PR DESCRIPTION
@mauve This should fix #89 

As a reference, it uses https://manual.macromates.com/en/language_grammars but written in JSON for some reason.

Basically regex for `^\s*(})` 
Intention:
- Match any `}` starting with 0 or more whitespaces
- It will not match if the `}` is not on a newline (as its not correct syntax anyway)
- Will match `}` for all resources.

AFAIK there is no way to match multi-line so I cant do a selector for all `{}` pairs and be done.