### PR TITLE
Allow brackets auto-closing in double quote strings

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -52,6 +52,7 @@
 			]
 		}
 	],
+	"autoCloseBefore": ";:.,=}])> \n\t\"",
 	"surroundingPairs": [
 		[
 			"{",


### PR DESCRIPTION
@mauve This should enable brackets autoclosing  to work with a new `Auto Closing Brackets` settings set to `languageDefined`

Ref: https://github.com/Microsoft/vscode/pull/52634