### PR TITLE
Fix variable autocomplete default placeholder

### DIFF
--- a/src/autocompletion/section-completions.ts
+++ b/src/autocompletion/section-completions.ts
@@ -27,7 +27,7 @@ function variableWithDocumentationAndValueCompletion(): vscode.CompletionItem {
     let snippet =
         'variable "${1:name}" {\n' +
         '  description = "${2:description}"\n' +
-        '  default = "${2:value}"\n' +
+        '  default = "${3:value}"\n' +
         '}\n' +
         '$0';
     item.insertText = new vscode.SnippetString(snippet);


### PR DESCRIPTION
Fixes cursor location for `value` under `variableWithDocumentationAndValueCompletion`.
Currently the `description` placeholder and cursor are copied under the `default` section.

![VSCode-Terraform_Variable_Autocomplete](https://user-images.githubusercontent.com/7484719/55181533-39cea680-5162-11e9-8eaf-23443e23ed76.png)
