### PR TITLE
Update syntax highlighting to better support terraform 0.12

### DIFF
--- a/syntaxes/terraform.json
+++ b/syntaxes/terraform.json
@@ -37,6 +37,11 @@
       "name": "constant.language.terraform"
     },
     {
+      "comment": "Primitive types",
+      "match": "\\b(string|number|bool)\\b",
+      "name": "support.type.primitive.terraform"
+    },
+    {
       "comment": "Numbers",
       "match": "\\b([0-9]+)([kKmMgG]b?)?\\b",
       "name": "constant.numeric.terraform"
@@ -136,6 +141,24 @@
       },
       "comment": "Value assignments (left hand side in double quotes)",
       "match": "(\")([\\w_-]+)(\")\\s*(=)\\s*"
+    },
+    {
+      "captures": {
+        "0": {
+          "name": "entity.name.function.terraform"
+        }
+      },
+      "comment": "Function Calls",
+      "match": "([\\w-]+)\\s*\\("
+    },
+    {
+      "captures": {
+        "0": {
+          "name": "variable.other.terraform"
+        }
+      },
+      "comment": "Variables",
+      "match": "([\\w-]+)"
     },
     {
       "captures": {


### PR DESCRIPTION
For #157 (but doesn't close it)

I have had a go at improving the syntax highlighting for Terraform 0.12 and beyond. I probably haven't fixed every case, but this should make it better especially for type definitions, expressions and function calls.

NOTE: this will not fix the erroneous syntax errors, but it will at least make the coloring better.

Also NOTE: this is my first time ever contributing to the project or any open source project, so please review closely, and let me know if I have done anything wrong.